### PR TITLE
Feature/separate routes from modules

### DIFF
--- a/src/app/layout/components/toolbar/toolbar.component.html
+++ b/src/app/layout/components/toolbar/toolbar.component.html
@@ -104,7 +104,7 @@
 
     <mat-menu #userMenu="matMenu" [overlapTrigger]="false">
 
-        <button mat-menu-item>
+        <button mat-menu-item routerLink="/general/pages/profile">
             <mat-icon>account_circle</mat-icon>
             <span>个人信息</span>
         </button>
@@ -116,7 +116,7 @@
 
         <mat-divider></mat-divider>
 
-        <button mat-menu-item>
+        <button mat-menu-item routerLink="/general/pages/login">
             <mat-icon>exit_to_app</mat-icon>
             <span>退出</span>
         </button>

--- a/src/app/layout/components/toolbar/toolbar.module.ts
+++ b/src/app/layout/components/toolbar/toolbar.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule, MatIconModule, MatMenuModule, MatToolbarModule, MatDividerModule } from '@angular/material';
 
@@ -10,6 +11,7 @@ import { ToolbarComponent } from './toolbar.component';
 @NgModule({
     imports: [
         CommonModule,
+        RouterModule,
 
         MatButtonModule,
         MatIconModule,

--- a/src/app/main/elements/basic-ui/basic-ui-routing.module.ts
+++ b/src/app/main/elements/basic-ui/basic-ui-routing.module.ts
@@ -24,16 +24,14 @@ const routes: Routes = [
         path: 'buttons',
         component: ButtonsComponent,
         data: {
-            title: '按钮',
-            hasContentHeader: true
+            title: '按钮'
         }
     },
     {
         path: 'cards',
         component: CardsComponent,
         data: {
-            title: '卡片',
-            hasContentHeader: true
+            title: '卡片'
         }
     },
     {
@@ -48,72 +46,63 @@ const routes: Routes = [
         path: 'list',
         component: ListComponent,
         data: {
-            title: '列表',
-            hasContentHeader: true
+            title: '列表'
         }
     },
     {
         path: 'badges',
         component: BadgesComponent,
         data: {
-            title: '徽章',
-            hasContentHeader: true
+            title: '徽章'
         }
     },
     {
         path: 'progress-bar',
         component: ProgressBarComponent,
         data: {
-            title: '进度条',
-            hasContentHeader: true
+            title: '进度条'
         }
     },
     {
         path: 'button-toggle',
         component: ButtonToggleComponent,
         data: {
-            title: '开关按钮',
-            hasContentHeader: true
+            title: '开关按钮'
         }
     },
     {
         path: 'chips',
         component: ChipsComponent,
         data: {
-            title: '标签',
-            hasContentHeader: true
+            title: '标签'
         }
     },
     {
         path: 'expansion-panel',
         component: ExpansionPanelComponent,
         data: {
-            title: '可展开面板',
-            hasContentHeader: true
+            title: '可展开面板'
         }
     },
     {
         path: 'tabs',
         component: TabsComponent,
         data: {
-            title: '选项卡',
-            hasContentHeader: true
+            title: '选项卡'
         }
     },
     {
         path: 'stepper',
         component: StepperComponent,
         data: {
-            title: '步进器',
-            hasContentHeader: true
+            title: '步进器'
         }
     },
     {
         path: 'grid-list',
         component: GridListComponent,
         data: {
-            title: '网格列表',
-            hasContentHeader: true
+            title: '网格列表'
         }
     }
 ];
@@ -122,7 +111,10 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes)
     ],
-    declarations: []
+    declarations: [],
+    exports: [
+        RouterModule
+    ]
 })
 export class BasicUiRoutingModule {
 }

--- a/src/app/main/elements/basic-ui/stepper/stepper.component.html
+++ b/src/app/main/elements/basic-ui/stepper/stepper.component.html
@@ -38,7 +38,7 @@
 
     <div class="content center">
         <h3>Vertical Stepper</h3>
-        <mat-vertical-stepper #stepper>
+        <mat-vertical-stepper #stepper2>
             <mat-step [stepControl]="firstFormGroup">
                 <form [formGroup]="firstFormGroup">
                     <ng-template matStepLabel>Fill out your name</ng-template>
@@ -67,7 +67,7 @@
                 You are now done.
                 <div>
                     <button mat-button matStepperPrevious>Back</button>
-                    <button mat-button (click)="stepper.reset()">Reset</button>
+                    <button mat-button (click)="stepper2.reset()">Reset</button>
                 </div>
             </mat-step>
         </mat-vertical-stepper>

--- a/src/app/main/elements/elements-routing.module.ts
+++ b/src/app/main/elements/elements-routing.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+    {
+        path: '',
+        redirectTo: 'basic-ui',
+        pathMatch: 'full',
+    },
+    {
+        path: 'basic-ui',
+        loadChildren: './basic-ui/basic-ui.module#BasicUiModule',
+        data: {
+            title: '基础 UI'
+        }
+    }
+];
+
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes)
+    ],
+    declarations: [],
+    exports: [
+        RouterModule
+    ]
+})
+export class ElementsRoutingModule {
+}

--- a/src/app/main/elements/elements.module.ts
+++ b/src/app/main/elements/elements.module.ts
@@ -1,23 +1,10 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-
-const routes: Routes = [
-    {
-        path: '',
-        redirectTo: 'basic-ui',
-        pathMatch: 'full',
-    },
-    {
-        path: 'basic-ui',
-        loadChildren: './basic-ui/basic-ui.module#BasicUiModule',
-        data: { title: '基础 UI' }
-    }
-];
+import { ElementsRoutingModule } from './elements-routing.module';
 
 @NgModule({
-  imports: [
-      RouterModule.forChild(routes)
-  ],
-  declarations: []
+    imports: [
+        ElementsRoutingModule
+    ],
+    declarations: []
 })
 export class ElementsModule { }

--- a/src/app/main/general/dashboards/analysis/analysis.component.html
+++ b/src/app/main/general/dashboards/analysis/analysis.component.html
@@ -1,5 +1,5 @@
 <div class="page-layout blank dashboard-analysis">
-    <section fxLayout="row wrap" fxLayout.gt-sm="row nowrap" fxLayoutAlign="space-between stretch" fxLayoutGap.md="15px" fxLayoutGap.lg="30px">
+    <section fxLayout="row wrap" fxLayout.gt-sm="row nowrap" fxLayoutAlign="space-between stretch" fxLayoutGap.md="15px" fxLayoutGap.gt-md="30px">
         <mat-card fxFlex="1 0 0%" fxFlex.xs="100" fxFlex.sm="48"
             *ngFor="let widget of widgets; let index = index;" 
             [ngClass.sm]="{'mb-20': index<2}" [ngClass.xs]="{'mb-20': index!==3}">
@@ -23,7 +23,7 @@
     </section>
     <section fxLayout="row nowrap" fxLayoutAlign="space-between center" fxLayoutGap.gt-sm="30px">
         <div fxFlex="1 0 0%" fxFlex.lt-md="100">
-            <ngx-amap class="map"></ngx-amap>
+            <!-- <ngx-amap class="map"></ngx-amap> -->
         </div>
         <div fxFlex="1 0 0%"></div>
     </section>

--- a/src/app/main/general/dashboards/dashboards-routing.module.ts
+++ b/src/app/main/general/dashboards/dashboards-routing.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { AnalysisComponent } from './analysis/analysis.component';
+
+const routes: Routes = [
+    {
+        path: '',
+        redirectTo: 'analytics',
+        pathMatch: 'full',
+    },
+    {
+        path: 'analytics',
+        component: AnalysisComponent,
+        data: {
+            title: '分析页',
+            hasContentHeader: false
+        }
+    }
+];
+
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes)
+    ],
+    declarations: [],
+    exports: [
+        RouterModule
+    ]
+})
+export class DashboardsRoutingModule {
+}

--- a/src/app/main/general/dashboards/dashboards.module.ts
+++ b/src/app/main/general/dashboards/dashboards.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
 import {
     MatButtonModule,
     MatFormFieldModule,
@@ -15,24 +14,10 @@ import { NgxAmapModule } from 'ngx-amap';
 import { NotaddSharedModule } from '@notadd/shared.module';
 import { NotaddPipesModule } from '@notadd/pipes/pipes.module';
 
-import { AnalysisService } from './analysis/analysis.service';
-import { AnalysisComponent } from './analysis/analysis.component';
+import { DashboardsRoutingModule } from './dashboards-routing.module';
 
-const routes: Routes = [
-    {
-        path: '',
-        redirectTo: 'analytics',
-        pathMatch: 'full',
-    },
-    {
-        path: 'analytics',
-        component: AnalysisComponent,
-        data: {
-            title: '分析页',
-            hasContentHeader: false
-        }
-    }
-];
+import { AnalysisComponent } from './analysis/analysis.component';
+import { AnalysisService } from './analysis/analysis.service';
 
 @NgModule({
     imports: [
@@ -51,7 +36,7 @@ const routes: Routes = [
         NotaddSharedModule,
         NotaddPipesModule,
 
-        RouterModule.forChild(routes)
+        DashboardsRoutingModule
     ],
     declarations: [
         AnalysisComponent

--- a/src/app/main/general/general-routing.module.ts
+++ b/src/app/main/general/general-routing.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+    {
+        path: '',
+        redirectTo: 'dashboards',
+        pathMatch: 'full',
+    },
+    {
+        path: 'dashboards',
+        loadChildren: './dashboards/dashboards.module#DashboardsModule',
+        data: {
+            title: '仪表盘'
+        }
+    },
+    {
+        path: 'pages',
+        loadChildren: './pages/pages.module#PagesModule',
+        data: {
+            title: '页面'
+        }
+    }
+];
+
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes)
+    ],
+    declarations: [],
+    exports: [
+        RouterModule
+    ]
+})
+export class GeneralRoutingModule {
+}

--- a/src/app/main/general/general.module.ts
+++ b/src/app/main/general/general.module.ts
@@ -1,31 +1,14 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
 
 import { NotaddSharedModule } from '@notadd/shared.module';
 
-const routs: Routes = [
-    {
-        path: '',
-        redirectTo: 'dashboards',
-        pathMatch: 'full',
-    },
-    {
-        path: 'dashboards',
-        loadChildren: './dashboards/dashboards.module#DashboardsModule',
-        data: { title: '仪表盘' }
-    },
-    {
-        path: 'pages',
-        loadChildren: './pages/pages.module#PagesModule',
-        data: { title: '页面' }
-    }
-];
+import { GeneralRoutingModule } from './general-routing.module';
 
 @NgModule(
     {
         imports: [
             NotaddSharedModule,
-            RouterModule.forChild(routs)
+            GeneralRoutingModule
         ]
     }
 )

--- a/src/app/main/general/pages/errors/errors.component.ts
+++ b/src/app/main/general/pages/errors/errors.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { NotaddConfigService } from '@notadd/services/config.service';
-
 @Component({
     selector: 'errors',
     templateUrl: './errors.component.html',
@@ -13,29 +11,11 @@ export class ErrorsComponent implements OnInit {
     code: string;
 
     constructor(
-        private activatedRoute: ActivatedRoute,
-        private notaddConfig: NotaddConfigService
+        private activatedRoute: ActivatedRoute
     ) {
         this.activatedRoute.params.subscribe(params => {
             this.code = params.code;
         });
-
-        this.notaddConfig.config = {
-            layout: {
-                navbar: {
-                    hidden: true
-                },
-                toolbar: {
-                    hidden: true
-                },
-                footer: {
-                    hidden: true
-                },
-                sidepanel: {
-                    hidden: true
-                }
-            }
-        };
     }
 
     ngOnInit() {

--- a/src/app/main/general/pages/forgot-password/forgot-password.component.ts
+++ b/src/app/main/general/pages/forgot-password/forgot-password.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { NotaddConfigService } from '@notadd/services/config.service';
-
 @Component({
     selector: 'forgot-password',
     templateUrl: './forgot-password.component.html',
@@ -9,26 +7,7 @@ import { NotaddConfigService } from '@notadd/services/config.service';
 })
 export class ForgotPasswordComponent implements OnInit {
 
-    constructor(
-        private notaddConfig: NotaddConfigService
-    ) {
-        this.notaddConfig.config = {
-            layout: {
-                navbar: {
-                    hidden: true
-                },
-                toolbar: {
-                    hidden: true
-                },
-                footer: {
-                    hidden: true
-                },
-                sidepanel: {
-                    hidden: true
-                }
-            }
-        };
-    }
+    constructor() {}
 
     ngOnInit() {
     }

--- a/src/app/main/general/pages/lockscreen/lockscreen.component.ts
+++ b/src/app/main/general/pages/lockscreen/lockscreen.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { NotaddConfigService } from '@notadd/services/config.service';
-
 @Component({
     selector: 'lockscreen',
     templateUrl: './lockscreen.component.html',
@@ -9,26 +7,7 @@ import { NotaddConfigService } from '@notadd/services/config.service';
 })
 export class LockscreenComponent implements OnInit {
 
-    constructor(
-        private notaddConfig: NotaddConfigService
-    ) {
-        this.notaddConfig.config = {
-            layout: {
-                navbar: {
-                    hidden: true
-                },
-                toolbar: {
-                    hidden: true
-                },
-                footer: {
-                    hidden: true
-                },
-                sidepanel: {
-                    hidden: true
-                }
-            }
-        };
-    }
+    constructor() {}
 
     ngOnInit() {
     }

--- a/src/app/main/general/pages/login-v2/login-v2.component.ts
+++ b/src/app/main/general/pages/login-v2/login-v2.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { NotaddConfigService } from '@notadd/services/config.service';
-
 @Component({
     selector: 'login-v2',
     templateUrl: './login-v2.component.html',
@@ -9,26 +7,7 @@ import { NotaddConfigService } from '@notadd/services/config.service';
 })
 export class LoginV2Component implements OnInit {
 
-    constructor(
-        private notaddConfig: NotaddConfigService
-    ) {
-        this.notaddConfig.config = {
-            layout: {
-                navbar   : {
-                    hidden: true
-                },
-                toolbar  : {
-                    hidden: true
-                },
-                footer   : {
-                    hidden: true
-                },
-                sidepanel: {
-                    hidden: true
-                }
-            }
-        };
-    }
+    constructor() {}
 
     ngOnInit() {
     }

--- a/src/app/main/general/pages/login/login.component.ts
+++ b/src/app/main/general/pages/login/login.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { NotaddConfigService } from '@notadd/services/config.service';
-
 @Component({
     selector: 'login',
     templateUrl: './login.component.html',
@@ -9,26 +7,7 @@ import { NotaddConfigService } from '@notadd/services/config.service';
 })
 export class LoginComponent implements OnInit {
 
-    constructor(
-        private notaddConfig: NotaddConfigService
-    ) {
-        this.notaddConfig.config = {
-            layout: {
-                navbar   : {
-                    hidden: true
-                },
-                toolbar  : {
-                    hidden: true
-                },
-                footer   : {
-                    hidden: true
-                },
-                sidepanel: {
-                    hidden: true
-                }
-            }
-        };
-    }
+    constructor() {}
 
     ngOnInit() {
     }

--- a/src/app/main/general/pages/pages-routing.module.ts
+++ b/src/app/main/general/pages/pages-routing.module.ts
@@ -1,0 +1,95 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { ProfileComponent } from './profile/profile.component';
+import { ErrorsComponent } from './errors/errors.component';
+import { LoginComponent } from './login/login.component';
+import { LoginV2Component } from './login-v2/login-v2.component';
+import { RegisterComponent } from './register/register.component';
+import { RegisterV2Component } from './register-v2/register-v2.component';
+import { ForgotPasswordComponent } from './forgot-password/forgot-password.component';
+import { LockscreenComponent } from './lockscreen/lockscreen.component';
+
+const routes: Routes = [
+    {
+        path: '',
+        redirectTo: 'profile',
+        pathMatch: 'full',
+    },
+    {
+        path: 'profile',
+        component: ProfileComponent,
+        data: {
+            title: '个人主页',
+            hasContentHeader: false
+        }
+    },
+    {
+        path: 'errors/:code',
+        component: ErrorsComponent,
+        data: {
+            title: '错误页',
+            isFullScreen: true
+        }
+    },
+    {
+        path: 'login',
+        component: LoginComponent,
+        data: {
+            title: '登录',
+            isFullScreen: true
+        }
+    },
+    {
+        path: 'login-v2',
+        component: LoginV2Component,
+        data: {
+            title: '登录 V2',
+            isFullScreen: true
+        }
+    },
+    {
+        path: 'register',
+        component: RegisterComponent,
+        data: {
+            title: '注册',
+            isFullScreen: true
+        }
+    },
+    {
+        path: 'register-v2',
+        component: RegisterV2Component,
+        data: {
+            title: '注册 V2',
+            isFullScreen: true
+        }
+    },
+    {
+        path: 'forgot-password',
+        component: ForgotPasswordComponent,
+        data: {
+            title: '忘记密码',
+            isFullScreen: true
+        }
+    },
+    {
+        path: 'lockscreen',
+        component: LockscreenComponent,
+        data: {
+            title: '锁定屏幕',
+            isFullScreen: true
+        }
+    }
+];
+
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes)
+    ],
+    declarations: [],
+    exports: [
+        RouterModule
+    ]
+})
+export class PagesRoutingModule {
+}

--- a/src/app/main/general/pages/pages.module.ts
+++ b/src/app/main/general/pages/pages.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
 
 import {
     MatCardModule,
@@ -14,6 +13,8 @@ import {
 
 import { NotaddSharedModule } from '@notadd/shared.module';
 
+import { PagesRoutingModule } from './pages-routing.module';
+
 import { ProfileComponent } from './profile/profile.component';
 import { ErrorsComponent } from './errors/errors.component';
 import { LoginComponent } from './login/login.component';
@@ -22,78 +23,6 @@ import { ForgotPasswordComponent } from './forgot-password/forgot-password.compo
 import { LockscreenComponent } from './lockscreen/lockscreen.component';
 import { RegisterComponent } from './register/register.component';
 import { RegisterV2Component } from './register-v2/register-v2.component';
-
-const routs: Routes = [
-    {
-        path: '',
-        redirectTo: 'profile',
-        pathMatch: 'full',
-    },
-    {
-        path: 'profile',
-        component: ProfileComponent,
-        data: {
-            title: '个人主页',
-            hasContentHeader: false
-        }
-    },
-    {
-        path: 'errors/:code',
-        component: ErrorsComponent,
-        data: {
-            title: '错误页',
-            isFullScreen: true
-        }
-    },
-    {
-        path: 'login',
-        component: LoginComponent,
-        data: {
-            title: '登录',
-            hasContentHeader: false
-        }
-    },
-    {
-        path: 'login-v2',
-        component: LoginV2Component,
-        data: {
-            title: '登录 V2',
-            hasContentHeader: false
-        }
-    },
-    {
-        path: 'register',
-        component: RegisterComponent,
-        data: {
-            title: '注册',
-            hasContentHeader: false
-        }
-    },
-    {
-        path: 'register-v2',
-        component: RegisterV2Component,
-        data: {
-            title: '注册 V2',
-            hasContentHeader: false
-        }
-    },
-    {
-        path: 'forgot-password',
-        component: ForgotPasswordComponent,
-        data: {
-            title: '忘记密码',
-            hasContentHeader: false
-        }
-    },
-    {
-        path: 'lockscreen',
-        component: LockscreenComponent,
-        data: {
-            title: '锁定屏幕',
-            hasContentHeader: false
-        }
-    }
-];
 
 @NgModule({
     imports: [
@@ -108,7 +37,7 @@ const routs: Routes = [
 
         NotaddSharedModule,
 
-        RouterModule.forChild(routs)
+        PagesRoutingModule
     ],
     declarations: [
         ProfileComponent,

--- a/src/app/main/general/pages/register-v2/register-v2.component.ts
+++ b/src/app/main/general/pages/register-v2/register-v2.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { NotaddConfigService } from '@notadd/services/config.service';
-
 @Component({
     selector: 'register-v2',
     templateUrl: './register-v2.component.html',
@@ -9,26 +7,7 @@ import { NotaddConfigService } from '@notadd/services/config.service';
 })
 export class RegisterV2Component implements OnInit {
 
-    constructor(
-        private notaddConfig: NotaddConfigService
-    ) {
-        this.notaddConfig.config = {
-            layout: {
-                navbar: {
-                    hidden: true
-                },
-                toolbar: {
-                    hidden: true
-                },
-                footer: {
-                    hidden: true
-                },
-                sidepanel: {
-                    hidden: true
-                }
-            }
-        };
-    }
+    constructor() {}
 
     ngOnInit() {
     }

--- a/src/app/main/general/pages/register/register.component.ts
+++ b/src/app/main/general/pages/register/register.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 
-import { NotaddConfigService } from '@notadd/services/config.service';
-
 @Component({
     selector: 'register',
     templateUrl: './register.component.html',
@@ -9,26 +7,7 @@ import { NotaddConfigService } from '@notadd/services/config.service';
 })
 export class RegisterComponent implements OnInit {
 
-    constructor(
-        private notaddConfig: NotaddConfigService
-    ) {
-        this.notaddConfig.config = {
-            layout: {
-                navbar: {
-                    hidden: true
-                },
-                toolbar: {
-                    hidden: true
-                },
-                footer: {
-                    hidden: true
-                },
-                sidepanel: {
-                    hidden: true
-                }
-            }
-        };
-    }
+    constructor() {}
 
     ngOnInit() {
     }


### PR DESCRIPTION
1. Separate routing module from modules
2. Delete default parameter `hasContentHeader:true`
3. Replace  modify `NotaddConfigService.config` in component.ts with add param `isFullScreen: true` in routing config module
4. Fix bug that the horizontal stepper cannot reset
5. Fix bug that four mat-cards of analysis component no gap when screen is `gt-md`
6. Add two jump links of toolbar